### PR TITLE
[MW-1364] Run embedded DEX code directly from APK

### DIFF
--- a/web_plugin/build.gradle.kts
+++ b/web_plugin/build.gradle.kts
@@ -54,6 +54,10 @@ android {
 
     testOptions.unitTests.isReturnDefaultValues = true
     testOptions.unitTests.isIncludeAndroidResources = true
+
+    aaptOptions {
+        noCompress("dex")
+    }
 }
 
 afterEvaluate {

--- a/web_plugin/src/main/AndroidManifest.xml
+++ b/web_plugin/src/main/AndroidManifest.xml
@@ -1,2 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.futureworkshops.mobileworkflow.plugin.web" />
+<manifest package="com.futureworkshops.mobileworkflow.plugin.web"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <application
+        android:useEmbeddedDex="true"/>
+</manifest>


### PR DESCRIPTION
[MW-1364](https://futureworkshops.atlassian.net/browse/MW-1364)
Run embedded DEX code directly from APK, this is done by adding 
* AndroidManifest.xml: Add **android:useEmbeddedDex="true"** to the **<application>** node
* In the app level build.gradle.xts, to avoid compression of the dex, add:
 aaptOptions {
        noCompress("dex")
  }

Reference: https://developer.android.com/topic/security/dex