### PR TITLE
MW-1751 add inner webView onBack support

### DIFF
--- a/web_plugin/src/main/java/com/futureworkshops/mobileworkflow/plugin/web/view/WebPluginView.kt
+++ b/web_plugin/src/main/java/com/futureworkshops/mobileworkflow/plugin/web/view/WebPluginView.kt
@@ -49,4 +49,6 @@ internal class WebPluginView(
     private fun viewUrl() {
         webView.loadUrl(url)
     }
+
+    override fun back() = if (webView.canGoBack()) webView.goBack() else super.back()
 }


### PR DESCRIPTION
Issue

- https://futureworkshops.atlassian.net/browse/MW-1751

Objective

- Enable back inner navigation in webViews

Solution

- override `back` method to allow webView control before handling it to the fragment