### PR TITLE
Plugin: Setup theme for Web

### DIFF
--- a/web_plugin/src/main/java/com/futureworkshops/mobileworkflow/plugin/web/view/WebPart.kt
+++ b/web_plugin/src/main/java/com/futureworkshops/mobileworkflow/plugin/web/view/WebPart.kt
@@ -11,10 +11,6 @@ import android.view.ViewGroup
 import androidx.annotation.LayoutRes
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.viewbinding.ViewBinding
-import com.futureworkshops.mobileworkflow.SurveyTheme
-import com.futureworkshops.mobileworkflow.backend.helpers.extensions.getTextColor
-import com.futureworkshops.mobileworkflow.backend.helpers.extensions.toColorStateList
-import com.futureworkshops.mobileworkflow.backend.views.main_parts.StyleablePart
 import com.futureworkshops.mobileworkflow.databinding.NextButtonBinding
 import com.futureworkshops.mobileworkflow.plugin.web.R
 import com.futureworkshops.mobileworkflow.plugin.web.databinding.WebStepBinding
@@ -23,7 +19,7 @@ class WebPart @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleRes: Int = 0,
-) : ConstraintLayout(context, attrs, defStyleRes), StyleablePart {
+) : ConstraintLayout(context, attrs, defStyleRes) {
 
     class WebPartBinding(
         context: Context,
@@ -31,7 +27,6 @@ class WebPart @JvmOverloads constructor(
         root: ViewGroup
     ): ViewBinding {
         private val innerView = WebStepBinding.bind(View.inflate(context, layout, root))
-        val progressBar = innerView.progressBar
         val webViewContainer = innerView.webViewContainer
         val webViewNextButton = NextButtonBinding.bind(getRoot().findViewById(R.id.webViewNextButton))
         override fun getRoot(): View = innerView.root
@@ -42,15 +37,6 @@ class WebPart @JvmOverloads constructor(
     }
 
     val view = WebPartBinding(context, R.layout.web_step, this)
-
-    override fun style(surveyTheme: SurveyTheme) {
-        val colorStateList = surveyTheme.themeColor.toColorStateList()
-        view.progressBar.indeterminateTintList = colorStateList
-        view.webViewNextButton.buttonContinue.apply {
-            backgroundTintList = colorStateList
-            setTextColor(surveyTheme.themeColor.getTextColor())
-        }
-    }
 
     fun setUpButton(showButton: Boolean, onClick: () -> Unit) {
         view.webViewNextButton.buttonContinue.apply {

--- a/web_plugin/src/main/java/com/futureworkshops/mobileworkflow/plugin/web/view/WebPluginView.kt
+++ b/web_plugin/src/main/java/com/futureworkshops/mobileworkflow/plugin/web/view/WebPluginView.kt
@@ -29,7 +29,6 @@ internal class WebPluginView(
         super.setupViews()
         context?.let {
             webPart = WebPart(it)
-            webPart.style(surveyTheme)
             content.add(webPart)
             webView = fragmentStepConfiguration.services.viewFactory.createWebView(it)
             webView.webViewClient = WebViewClient()

--- a/web_plugin/src/main/res/layout/web_step.xml
+++ b/web_plugin/src/main/res/layout/web_step.xml
@@ -30,6 +30,7 @@
     <androidx.core.widget.ContentLoadingProgressBar
         android:id="@+id/progressBar"
         style="?android:attr/progressBarStyle"
+        android:indeterminateTint="?attr/colorPrimary"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:visibility="gone"


### PR DESCRIPTION
### Checklist

- [x] I've validated if any R8 rule should be added to the relevant proguard-rules.pro file. More info about it [on Confluence](https://futureworkshops.atlassian.net/wiki/spaces/FMW/pages/2319187983/Validate+R8+rules+for+core+and+plugins)
- [X] If I'm updating a plugin submodule, I'm sure that the reference on the submodule is on `main`

### Task

[Plugin: Setup theme for Web](https://3.basecamp.com/5245563/buckets/26795773/todos/4777893544)

### Feature/Issue

Currently Webview plugin step does not use the theme of the app.

### Implementation

Fix UI elements to use theme colors.

Example using custom theme colors to emphasize the use of theme colors:
![webview_light](https://user-images.githubusercontent.com/49487374/165094868-8b4ef9e6-485e-48dc-af51-80878394ba35.png)
![webview_dark](https://user-images.githubusercontent.com/49487374/165094859-c8e143cd-64fa-49e9-9929-0be087dbec2b.png)