### PR TITLE
Dynamic URLs are not working for web view step

### DIFF
--- a/web_plugin/src/main/java/com/futureworkshops/mobileworkflow/plugin/web/view/UIWebPluginStep.kt
+++ b/web_plugin/src/main/java/com/futureworkshops/mobileworkflow/plugin/web/view/UIWebPluginStep.kt
@@ -23,12 +23,19 @@ internal data class UIWebPluginStep(
         stepResult: AnswerResult?,
         services: ServiceBox,
         appServiceResponse: AppServiceResponse
-    ): FragmentStep = WebPluginView(
+    ): FragmentStep {
+        val resolvedURL = services.urlTaskBuilder.urlHelper.resolveUrl(
+            appServiceResponse.server,
+            url,
+            appServiceResponse.session
+        )?:url
+
+        return WebPluginView(
         FragmentStepConfiguration(
                 title = services.localizationService.getTranslation(title),
         text = null,
         nextButtonText = services.localizationService.getTranslation(nextButtonText),
         services = services),
-        url = url
-    )
+        url = resolvedURL)
+    }
 }


### PR DESCRIPTION
### Checklist

- [x] I've validated if any R8 rule should be added to the relevant proguard-rules.pro file. More info about it [on Confluence](https://futureworkshops.atlassian.net/wiki/spaces/FMW/pages/2319187983/Validate+R8+rules+for+core+and+plugins)
- [X] If I'm updating a plugin submodule, I'm sure that the reference on the submodule is on `main`

### Task

[[iOS] [Android] Dynamic URLs are not working for web view step](https://3.basecamp.com/5245563/buckets/26145695/todos/4866450512)

### Feature/Issue

Currently the Webview plugin step does resolve the url using the server/session.

### Implementation

Resolve the url using the server and session, fallback to the url. 
