### PR TITLE
[Android] 🟡 TikTok links are not opening correctly

### DIFF
--- a/web_plugin/src/main/java/com/futureworkshops/mobileworkflow/plugin/web/view/WebPluginView.kt
+++ b/web_plugin/src/main/java/com/futureworkshops/mobileworkflow/plugin/web/view/WebPluginView.kt
@@ -5,7 +5,6 @@
 package com.futureworkshops.mobileworkflow.plugin.web.view
 
 import android.annotation.SuppressLint
-import android.content.Context
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
@@ -58,8 +57,11 @@ internal class WebPluginView(
             }
         }
         webView.webChromeClient = LoggerWebChromeClient(safeContext, logger)
-        @SuppressLint("SetJavaScriptEnabled")
-        webView.settings.javaScriptEnabled = true
+        webView.settings.apply {
+            @SuppressLint("SetJavaScriptEnabled")
+            javaScriptEnabled = true
+            domStorageEnabled = true
+        }
         webPart.view.webViewContainer.addView(webView)
 
         enableFullScreen()


### PR DESCRIPTION
### Task

[[Android] 🟡 TikTok links are not opening correctly](https://3.basecamp.com/5245563/buckets/26112855/todos/5832236897)

### Issue

TikTok uses [Web storage](https://www.w3schools.com/html/html5_webstorage.asp) to optimise video play. Not having access to this functionality makes the page throw:

```
[2] TypeError: Cannot read properties of null (reading 'getItem')
[1] Error occurs in render time: TypeError: Cannot read properties of null (reading 'getItem')
[0]: Uncaught (in promise) AbortError: The play() request was interrupted because the media was removed from the document. https://goo.gl/LdLk22
```

https://user-images.githubusercontent.com/2117340/220720097-fcfb7e0a-9367-4c95-95f0-56859ecb9ce8.mp4

### Implementation

Allow DOM (local) storage in the Webview to allow TikTok page support

https://user-images.githubusercontent.com/2117340/220720527-85ebbbe5-ed9c-483c-9234-0e3f2ab574f4.mp4


