### PR TITLE
[Android] [WebView] [Low] Fullscreen button for video is not working

### DIFF
--- a/web_plugin/src/main/java/com/futureworkshops/mobileworkflow/plugin/web/view/WebPluginView.kt
+++ b/web_plugin/src/main/java/com/futureworkshops/mobileworkflow/plugin/web/view/WebPluginView.kt
@@ -56,7 +56,7 @@ internal class WebPluginView(
                 super.onPageFinished(view, url)
             }
         }
-        webView.webChromeClient = LoggerWebChromeClient(safeContext, logger)
+        webView.webChromeClient = LoggerWebChromeClient(safeContext, logger, activity)
         webView.settings.apply {
             @SuppressLint("SetJavaScriptEnabled")
             javaScriptEnabled = true

--- a/web_plugin/src/main/java/com/futureworkshops/mobileworkflow/plugin/web/view/webview/LoggerWebChromeClient.kt
+++ b/web_plugin/src/main/java/com/futureworkshops/mobileworkflow/plugin/web/view/webview/LoggerWebChromeClient.kt
@@ -4,9 +4,12 @@
 
 package com.futureworkshops.mobileworkflow.plugin.web.view.webview
 
+import android.app.Activity
 import android.content.Context
+import android.view.View
 import android.webkit.ConsoleMessage
 import android.webkit.WebChromeClient
+import android.widget.FrameLayout
 import com.futureworkshops.mobileworkflow.domain.service.log.Logger
 import com.futureworkshops.mobileworkflow.model.log.LogLevel
 
@@ -32,10 +35,31 @@ fun ConsoleMessage.logMessage(
 
 open class LoggerWebChromeClient(
     private val context: Context,
-    private val logger: Logger
+    private val logger: Logger,
+    private val activity: Activity?
 ): WebChromeClient() {
+    private var customView: View? = null
+
     override fun onConsoleMessage(consoleMessage: ConsoleMessage?): Boolean {
         consoleMessage?.logMessage(context, logger)
         return true
+    }
+
+    override fun onHideCustomView() {
+        activity?.let {
+            (it.window.decorView as FrameLayout).removeView(customView)
+            customView = null
+        }
+    }
+
+    override fun onShowCustomView(paramView: View, paramCustomViewCallback: CustomViewCallback) {
+        if (customView != null) {
+            onHideCustomView()
+            return
+        }
+        activity?.let {
+            customView = paramView
+            (it.window.decorView as FrameLayout).addView(customView,  FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT))
+        }
     }
 }

--- a/web_plugin/src/main/java/com/futureworkshops/mobileworkflow/plugin/web/view/webview/LoggerWebChromeClient.kt
+++ b/web_plugin/src/main/java/com/futureworkshops/mobileworkflow/plugin/web/view/webview/LoggerWebChromeClient.kt
@@ -55,7 +55,6 @@ open class LoggerWebChromeClient(
     override fun onShowCustomView(paramView: View, paramCustomViewCallback: CustomViewCallback) {
         if (customView != null) {
             onHideCustomView()
-            return
         }
         activity?.let {
             customView = paramView


### PR DESCRIPTION
### Checklist

- [X] I've validated if any R8 rule should be added to the relevant proguard-rules.pro file. More info about it [on Basecamp](https://3.basecamp.com/5245563/buckets/26145695/documents/5081594699)
- [X] If I'm updating a plugin submodule, I'm sure that the reference on the submodule is on `main`
- [X] I've validated that I am using annotation @SerializedName for Parcelable object properties, even if the string is the same as the parameter.

### Task

[[Android] [WebView] [Low] Fullscreen button for video is not working](https://3.basecamp.com/5245563/buckets/26145695/todos/58906215947)

### Feature/Issue

Currently when loading youtube in a webview, when tapping Fullscreen button on the video player is not working.

### Implementation

Handle onShowCustomView, to notify the application that the current page has entered full screen mode and handle that view.

https://user-images.githubusercontent.com/49487374/222501904-27bcf46b-091d-4c8c-8d02-c6588664707b.mp4
