### PR TITLE
[iOS][Android] Add Share Button to Web step

### DIFF
--- a/web_plugin/src/main/java/com/futureworkshops/mobileworkflow/plugin/web/WebPlugin.kt
+++ b/web_plugin/src/main/java/com/futureworkshops/mobileworkflow/plugin/web/WebPlugin.kt
@@ -21,6 +21,7 @@ internal class WebPlugin : DeserializeStep<WebPluginStep>(
             id = step.id,
             url = step.url,
             hideNavigation = step.hideNavigation ?: false,
-            hideToolbar = step.hideToolbar ?: false
+            hideToolbar = step.hideToolbar ?: false,
+            showShareOption = step.sharingEnabled ?: false,
         )
 }

--- a/web_plugin/src/main/java/com/futureworkshops/mobileworkflow/plugin/web/step/WebPluginStep.kt
+++ b/web_plugin/src/main/java/com/futureworkshops/mobileworkflow/plugin/web/step/WebPluginStep.kt
@@ -21,5 +21,6 @@ data class WebPluginStep(
     @SerializedName("optional") val optional: Boolean,
     @SerializedName("url") val url: String,
     @SerializedName("hideNavigation") val hideNavigation: Boolean?,
-    @SerializedName("hideTopNavigationBar") val hideToolbar: Boolean?
+    @SerializedName("hideTopNavigationBar") val hideToolbar: Boolean?,
+    @SerializedName("sharingEnabled") val sharingEnabled: Boolean?
 ) : PluginStep(), Parcelable

--- a/web_plugin/src/main/java/com/futureworkshops/mobileworkflow/plugin/web/view/UIWebPluginStep.kt
+++ b/web_plugin/src/main/java/com/futureworkshops/mobileworkflow/plugin/web/view/UIWebPluginStep.kt
@@ -19,11 +19,20 @@ internal data class UIWebPluginStep(
     override val id: String,
     private val hideNavigation: Boolean,
     private val hideToolbar: Boolean,
-    private val nextButtonText: String = "Next"
+    private val nextButtonText: String = "Next",
+    private val showShareOption: Boolean
 ) : Step, DataTitle {
 
     override fun copyWithNewTitle(title: String): Step {
-        return UIWebPluginStep(title, url, id, hideNavigation, hideToolbar, nextButtonText)
+        return UIWebPluginStep(
+            title = title,
+            url = url,
+            id = id,
+            hideNavigation = hideNavigation,
+            hideToolbar = hideToolbar,
+            nextButtonText = nextButtonText,
+            showShareOption = showShareOption
+        )
     }
 
     override fun createView(
@@ -46,7 +55,8 @@ internal data class UIWebPluginStep(
             ),
             url = resolvedURL,
             hideNavigation = hideNavigation,
-            hideToolbar = hideToolbar
+            hideToolbar = hideToolbar,
+            showShareOption = showShareOption
         )
     }
 }

--- a/web_plugin/src/main/java/com/futureworkshops/mobileworkflow/plugin/web/view/WebPart.kt
+++ b/web_plugin/src/main/java/com/futureworkshops/mobileworkflow/plugin/web/view/WebPart.kt
@@ -14,6 +14,7 @@ import androidx.core.widget.ContentLoadingProgressBar
 import androidx.viewbinding.ViewBinding
 import com.futureworkshops.mobileworkflow.databinding.NextButtonBinding
 import com.futureworkshops.mobileworkflow.plugin.web.R
+import com.futureworkshops.mobileworkflow.plugin.web.databinding.ShareButtonBinding
 import com.futureworkshops.mobileworkflow.plugin.web.databinding.WebStepBinding
 
 class WebPart @JvmOverloads constructor(
@@ -31,6 +32,7 @@ class WebPart @JvmOverloads constructor(
         val webViewContainer
             get() = innerView.webViewContainer
         val webViewNextButton = NextButtonBinding.bind(getRoot().findViewById(R.id.webViewNextButton))
+        val webViewShareButton = ShareButtonBinding.bind(getRoot().findViewById(R.id.webViewShareButton))
         val progressBar
             get() = innerView.progressBar
         override fun getRoot(): View = innerView.root
@@ -44,8 +46,15 @@ class WebPart @JvmOverloads constructor(
     val progressBar: ContentLoadingProgressBar
         get() = view.progressBar
 
-    fun setUpButton(showButton: Boolean, onClick: () -> Unit) {
+    fun setUpNextButton(showButton: Boolean, onClick: () -> Unit) {
         view.webViewNextButton.buttonContinue.apply {
+            visibility = if (showButton) View.VISIBLE else View.GONE
+            setOnClickListener { onClick() }
+        }
+    }
+
+    fun setUpShareButton(showButton: Boolean, onClick: () -> Unit) {
+        view.webViewShareButton.buttonShare.apply {
             visibility = if (showButton) View.VISIBLE else View.GONE
             setOnClickListener { onClick() }
         }

--- a/web_plugin/src/main/java/com/futureworkshops/mobileworkflow/plugin/web/view/WebPluginView.kt
+++ b/web_plugin/src/main/java/com/futureworkshops/mobileworkflow/plugin/web/view/WebPluginView.kt
@@ -12,9 +12,14 @@ import android.view.View
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.activity.addCallback
+import androidx.core.content.ContextCompat
+import androidx.core.graphics.drawable.DrawableCompat
+import com.futureworkshops.mobileworkflow.backend.helpers.extensions.toColorStateList
 import com.futureworkshops.mobileworkflow.backend.views.step.FragmentStep
 import com.futureworkshops.mobileworkflow.backend.views.step.FragmentStepConfiguration
 import com.futureworkshops.mobileworkflow.domain.service.log.Logger
+import com.futureworkshops.mobileworkflow.extensions.buildChooserShareText
+import com.futureworkshops.mobileworkflow.extensions.colorOnPrimarySurface
 import com.futureworkshops.mobileworkflow.model.result.AnswerResult
 import com.futureworkshops.mobileworkflow.model.result.EmptyAnswerResult
 import com.futureworkshops.mobileworkflow.plugin.web.R
@@ -26,7 +31,8 @@ internal class WebPluginView(
     private val url: String,
     private val hideNavigation: Boolean,
     private val hideToolbar: Boolean,
-    private val logger: Logger = Logger.sharedInstance
+    private val logger: Logger = Logger.sharedInstance,
+    private val showShareOption: Boolean
 ) : FragmentStep(fragmentStepConfiguration) {
 
     private lateinit var webView: WebView
@@ -40,6 +46,8 @@ internal class WebPluginView(
 
     override fun getStepOutput(): AnswerResult = EmptyAnswerResult()
     override fun isValidInput(): Boolean = true
+
+    private var isShareShown: Boolean = false
 
     override fun setupViews() {
         super.setupViews()
@@ -67,6 +75,11 @@ internal class WebPluginView(
         enableFullScreen()
         setUpFooter()
         viewUrl()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        isShareShown = false
     }
 
     override fun onViewCreated() {
@@ -106,24 +119,54 @@ internal class WebPluginView(
                 R.id.next_menu_item,
                 0,
                 fragmentStepConfiguration.nextButtonText
-            ) ?: return
-            menuItem.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
+            )
+            menuItem?.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
         }
+
+        configureShareMenu(menu)
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        if (item.itemId == android.R.id.home) {
-            //For the toolbar home, we are always going one step up.
-            super.back()
-            return true
+        return when {
+            item.itemId == android.R.id.home -> {
+                //For the toolbar home, we are always going one step up.
+                super.back()
+                true
+            }
+            item.itemId == R.id.share_menu_item -> {
+                shareUrl()
+            }
+            !hideNavigation || item.itemId != R.id.next_menu_item -> {
+                super.onOptionsItemSelected(item)
+            }
+            else -> {
+                footer.onContinue()
+                true
+            }
+        }
+    }
+
+    private fun shareUrl(): Boolean {
+        if (!isShareShown) {
+            context?.startActivity(
+                buildChooserShareText(url)
+            )
+            isShareShown = true
         }
 
-        if (!hideNavigation || item.itemId != R.id.next_menu_item) {
-            return super.onOptionsItemSelected(item)
-        }
-
-        footer.onContinue()
         return true
+    }
+
+    private fun configureShareMenu(menu: Menu) {
+
+        val shareMenu = menu.add(Menu.NONE, R.id.share_menu_item, 0, R.string.menu_item_share)
+        shareMenu.icon = ContextCompat.getDrawable(requireContext(), com.futureworkshops.mobileworkflow.R.drawable.ic_share)?.apply {
+            DrawableCompat.setTintList(this, requireContext().colorOnPrimarySurface.toColorStateList())
+        }
+        shareMenu.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
+
+        shareMenu.isVisible = showShareOption
+
     }
 
     private fun showLoading() {

--- a/web_plugin/src/main/java/com/futureworkshops/mobileworkflow/plugin/web/view/WebPluginView.kt
+++ b/web_plugin/src/main/java/com/futureworkshops/mobileworkflow/plugin/web/view/WebPluginView.kt
@@ -43,6 +43,8 @@ internal class WebPluginView(
         set(value) { super.showHeader = value }
     private val shouldShowNextButton: Boolean
         get() = if (hideNavigation) { false } else { showContinue }
+    private val shouldShowShareButton: Boolean
+        get() = if (hideNavigation) { false } else { showShareOption }
 
     override fun getStepOutput(): AnswerResult = EmptyAnswerResult()
     override fun isValidInput(): Boolean = true
@@ -98,8 +100,13 @@ internal class WebPluginView(
         content.hideFooterContainer()
     }
 
-    private fun setUpFooter() = webPart.setUpButton(shouldShowNextButton) {
-        footer.onContinue()
+    private fun setUpFooter() {
+        webPart.setUpNextButton(shouldShowNextButton) {
+            footer.onContinue()
+        }
+        webPart.setUpShareButton(shouldShowShareButton) {
+            shareUrl()
+        }
     }
 
     private fun viewUrl() {
@@ -165,7 +172,7 @@ internal class WebPluginView(
         }
         shareMenu.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
 
-        shareMenu.isVisible = showShareOption
+        shareMenu.isVisible = showShareOption && hideNavigation
 
     }
 

--- a/web_plugin/src/main/res/layout/share_button.xml
+++ b/web_plugin/src/main/res/layout/share_button.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2021 FutureWorkshops. All rights reserved.
+  -->
+
+<com.google.android.material.button.MaterialButton xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/button_share"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center_horizontal"
+    android:layout_marginHorizontal="@dimen/step_vertical_padding"
+    android:layout_marginVertical="@dimen/button_padding_vertical"
+    android:stateListAnimator="@drawable/app_rail_button_selector"
+    android:text="@string/action_share"/>

--- a/web_plugin/src/main/res/layout/web_step.xml
+++ b/web_plugin/src/main/res/layout/web_step.xml
@@ -22,6 +22,16 @@
         layout="@layout/next_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        app:layout_constraintBottom_toTopOf="@id/webViewShareButton"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/webViewContainer" />
+
+    <include
+        android:id="@+id/webViewShareButton"
+        layout="@layout/share_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/web_plugin/src/main/res/values-ar/strings.xml
+++ b/web_plugin/src/main/res/values-ar/strings.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
     <string name="menu_item_share">Share</string>
+    <string name="action_share">Share</string>
 </resources>

--- a/web_plugin/src/main/res/values-ar/strings.xml
+++ b/web_plugin/src/main/res/values-ar/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="menu_item_share">Share</string>
+</resources>

--- a/web_plugin/src/main/res/values/ids.xml
+++ b/web_plugin/src/main/res/values/ids.xml
@@ -3,4 +3,5 @@
   -->
 <resources>
     <item name="next_menu_item" type="id" />
+    <item name="share_menu_item" type="id" />
 </resources>

--- a/web_plugin/src/main/res/values/strings.xml
+++ b/web_plugin/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="menu_item_share">Share</string>
+    <string name="action_share">Share</string>
 </resources>

--- a/web_plugin/src/main/res/values/strings.xml
+++ b/web_plugin/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="menu_item_share">Share</string>
+</resources>


### PR DESCRIPTION
### Checklist

- [X] I've validated if any R8 rule should be added to the relevant proguard-rules.pro file. More info about it [on Basecamp](https://3.basecamp.com/5245563/buckets/26145695/documents/5081594699)
- [X] If I'm updating a plugin submodule, I'm sure that the reference on the submodule is on `main`
- [X] I've validated that I am using annotation @SerializedName for Parcelable object properties, even if the string is the same as the parameter.

### Task

[[iOS][Android] Add Share Button to Web step
](https://3.basecamp.com/5245563/buckets/26145695/todos/5900337702)
### Feature/Issue

Add Share button, same as in PDF Viewer step.

### Implementation

Add share button to Webview step to the toolbar, as on the PDF Viewer step.
Because the the toolbar might be removed in the Webview, add similar logic of the next button (Adding to the bottom bar). Examples shown in the demo video:

https://user-images.githubusercontent.com/49487374/223467159-cdbb749f-9b0f-4f42-9b40-17f2ca4fba02.mp4


