### PR TITLE
[iOS][Android] Add Share Button to Web step

### DIFF
--- a/web_plugin/src/main/res/layout/web_step.xml
+++ b/web_plugin/src/main/res/layout/web_step.xml
@@ -22,9 +22,9 @@
         layout="@layout/next_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:layout_constraintBottom_toTopOf="@id/webViewShareButton"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@id/webViewShareButton"
         app:layout_constraintTop_toBottomOf="@id/webViewContainer" />
 
     <include
@@ -33,7 +33,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/webViewNextButton"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/webViewContainer" />
 


### PR DESCRIPTION
### Checklist

- [X] I've validated if any R8 rule should be added to the relevant proguard-rules.pro file. More info about it [on Basecamp](https://3.basecamp.com/5245563/buckets/26145695/documents/5081594699)
- [X] If I'm updating a plugin submodule, I'm sure that the reference on the submodule is on `main`
- [X] I've validated that I am using annotation @SerializedName for Parcelable object properties, even if the string is the same as the parameter.

### Task

[[iOS][Android] Add Share Button to Web step
](https://3.basecamp.com/5245563/buckets/26145695/todos/5900337702)

### Feature/Issue

As part of this task, the share and next buttons in the bottom bar should be side-by-side, instead one on top of the other.

### Implementation

Change bottom bar buttons alignment to side by side. Example with and without share button:
![share](https://user-images.githubusercontent.com/49487374/224039146-e87394dd-0761-4610-a3d8-0d5a8f695c30.png)
![no_share](https://user-images.githubusercontent.com/49487374/224039155-75b16fa3-edf4-46c4-a553-5fe4b45775a7.png)
